### PR TITLE
Fix issue 11 | Dynamic resources dont work with Skeleton 

### DIFF
--- a/Xamarin.Forms.Skeleton/Extensions/ViewExtensions.cs
+++ b/Xamarin.Forms.Skeleton/Extensions/ViewExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Skeleton.Extensions
+{
+    internal static class ViewExtensions
+    {
+        #region Internal Methods
+
+        /// <summary>
+        /// Check if property has dynamic color resource associated
+        /// </summary>
+        /// <typeparam name="TView">View type</typeparam>
+        /// <param name="view">View object</param>
+        /// <param name="property">Bindable property to check</param>
+        /// <returns>True if any associated Setter found</returns>
+        internal static bool HasDynamicColorOnProperty<TView>(this TView view, BindableProperty property) where TView : View
+        {
+            var resourceValue = view?.GetPropertyDynamicResourceValue(property);
+            if (resourceValue == null) return false;
+
+            var currentValue = GetValueFromPropertyName(view, property.PropertyName);
+            return currentValue != null && (Color)currentValue == (Color)resourceValue;
+        }
+
+        /// <summary>
+        /// Get value from dynamic resource associated to property
+        /// </summary>
+        /// <typeparam name="TView">View type</typeparam>
+        /// <param name="view">View object</param>
+        /// <param name="property">Bindable property to check</param>
+        /// <returns>Associated resource value</returns>
+        internal static object GetPropertyDynamicResourceValue<TView>(this TView view, BindableProperty property) where TView : View
+        {
+            var resourceKey = view.GetPropertyDynamicResourceKey(property);
+
+            if (string.IsNullOrWhiteSpace(resourceKey))
+                return null;
+
+            var currentResources = Application.Current.Resources;
+            if (!currentResources.TryGetValue(resourceKey, out var resourceValue))
+                return null;
+
+            return resourceValue;
+        }
+
+        /// <summary>
+        /// Get key from dynamic resource associated to property
+        /// </summary>
+        /// <typeparam name="TView">View type</typeparam>
+        /// <param name="view">View object</param>
+        /// <param name="property">Bindable property to check</param>
+        /// <returns>Associated resource key</returns>
+        internal static string GetPropertyDynamicResourceKey<TView>(this TView view, BindableProperty propertyToCheck) where TView : View
+        {
+            var elementStyle = view?.Style;
+            var styleSetters = GetAllSetters(elementStyle);
+            var setter = styleSetters?.FirstOrDefault(
+                s => s.Property.PropertyName == propertyToCheck.PropertyName);
+
+            if (setter?.Value is DynamicResource dynamicResource)
+                return dynamicResource.Key;
+
+            return null;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private static IEnumerable<Setter> GetAllSetters(Style style)
+        {
+            if (style == null)
+                return Enumerable.Empty<Setter>();
+
+            return style.Setters.Concat(GetAllSetters(style.BasedOn));
+        }
+
+        private static object GetValueFromPropertyName(object view, string propertyToCheck) =>
+            view.GetType().GetProperty(propertyToCheck).GetValue(view);
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Description
I've created some validations for Dynamic Setters on views to keep it working as expected
Fixes: #11  

## Changes
- I've added HasDynamicTextColor/BackgroundColor property;
- I've created ViewExtensions
- I've changed the "restore original color" logic to check dynamic values;

## Preview
<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/42358163/75993425-326a5e00-5ed8-11ea-8ca7-abab479444ee.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>
