### PR TITLE
Fix issue #9 | Open to custom animations

### DIFF
--- a/SkeletonExample/SkeletonExample/MainPage.xaml.cs
+++ b/SkeletonExample/SkeletonExample/MainPage.xaml.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using SkeletonExample.Pages;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using SkeletonExample.Pages;
 using Xamarin.Forms;
 
 namespace SkeletonExample
@@ -20,6 +15,7 @@ namespace SkeletonExample
             this.Children.Add(new Page3());
             this.Children.Add(new Page4());
             this.Children.Add(new Page5());
+            this.Children.Add(new Page6());
         }
     }
 }

--- a/SkeletonExample/SkeletonExample/MyCustomAnimation.cs
+++ b/SkeletonExample/SkeletonExample/MyCustomAnimation.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Forms;
+using Xamarin.Forms.Skeleton.Animations;
+
+namespace SkeletonExample
+{
+    public sealed class MyCustomAnimation : BaseAnimation
+    {
+        private const int DEFAULT_DURATION = 500;
+        protected override async Task<bool> Animate(BindableObject bindable)
+        {
+            if (bindable is View target)
+            {
+                //Rotate to 90 degrees and fade to 75% of opacity
+                await Task.WhenAll(target.FadeTo(0.75, DEFAULT_DURATION),
+                    target.RotateYTo(90, DEFAULT_DURATION, Easing.Linear));
+
+                //Rotate to -90 degrees and fade to 50% of opacity
+                await Task.WhenAll(target.FadeTo(50),
+                    target.RotateYTo(-90, DEFAULT_DURATION, Easing.Linear));
+
+                //Reset rotation and fade to 100% of opacity
+                await Task.WhenAll(target.FadeTo(1, DEFAULT_DURATION), target.RotateYTo(0, DEFAULT_DURATION));
+
+                //Is animating
+                return true;
+            }
+
+            return false;
+        }
+
+        protected override async Task StopAnimation(BindableObject bindable)
+        {
+            //Recovery state immediately
+            if (bindable is View target)
+                await Task.WhenAll(target.FadeTo(1, 1), target.RotateYTo(0, 1));
+        }
+    }
+}

--- a/SkeletonExample/SkeletonExample/Pages/Page1.xaml
+++ b/SkeletonExample/SkeletonExample/Pages/Page1.xaml
@@ -3,7 +3,7 @@
     xmlns:pages="clr-namespace:SkeletonExample.Pages"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:extension="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
+    xmlns:sk="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
     xmlns:ffimageloading="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms"
     x:Class="SkeletonExample.Pages.Page1"
     Title="Skeleton">
@@ -17,9 +17,9 @@
                            IsClippedToBounds="True"
                            Margin="10,0,10,16"
                            BackgroundColor="{StaticResource BlueColor}"
-                           extension:Skeleton.IsParent="True"
-                           extension:Skeleton.IsBusy="{Binding IsBusy}"
-                           extension:Skeleton.BackgroundColor="{StaticResource BlueColor}">
+                           sk:Skeleton.IsParent="True"
+                           sk:Skeleton.IsBusy="{Binding IsBusy}"
+                           sk:Skeleton.BackgroundColor="{StaticResource BlueColor}">
                         <AbsoluteLayout HeightRequest="200">
                             <ffimageloading:CachedImage Source="{Binding Image}"
                                                         Aspect="AspectFill"
@@ -29,8 +29,8 @@
                                                         Aspect="AspectFill"
                                                         AbsoluteLayout.LayoutFlags="All"
                                                         AbsoluteLayout.LayoutBounds="0,0,1,1"
-                                                        extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                                        extension:Skeleton.Hide="True" />
+                                                        sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                                        sk:Skeleton.Hide="True" />
                             <StackLayout Padding="16,12"
                                          Spacing="4"
                                          Orientation="Horizontal"
@@ -41,15 +41,15 @@
                                        FontSize="Title"
                                        FontAttributes="Bold"
                                        HorizontalOptions="FillAndExpand"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                                 <Label
                                     Text="{Binding Subtitle}"
                                     TextColor="{StaticResource WhiteColor}"
                                     FontSize="Medium"
                                     VerticalOptions="Center"
-                                    extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                    extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                    sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                    sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                             </StackLayout>
                         </AbsoluteLayout>
                     </Frame>
@@ -93,9 +93,9 @@
                       BackgroundColor="Transparent"
                       ItemTemplate="{StaticResource ItemTemplate}"
                       ItemsSource="{Binding Items}"
-                      extension:Skeleton.IsParent="True"
-                      extension:Skeleton.IsBusy="{Binding IsBusy}"
-                      extension:Skeleton.Animation="Fade" />
+                      sk:Skeleton.IsParent="True"
+                      sk:Skeleton.IsBusy="{Binding IsBusy}"
+                      sk:Skeleton.Animation="{sk:DefaultAnimation Fade}" />
         </Grid>
     </ContentPage.Content>
 </pages:BasePage>

--- a/SkeletonExample/SkeletonExample/Pages/Page2.xaml
+++ b/SkeletonExample/SkeletonExample/Pages/Page2.xaml
@@ -3,7 +3,7 @@
     xmlns:pages="clr-namespace:SkeletonExample.Pages"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:extension="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
+    xmlns:sk="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
     xmlns:ffimageloading="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms"
     xmlns:material="clr-namespace:Plugin.MaterialDesignControls;assembly=Plugin.MaterialDesignControls"
     x:Class="SkeletonExample.Pages.Page2"
@@ -42,18 +42,18 @@
 
                     <StackLayout Spacing="8"
                                  Padding="16"
-                                 extension:Skeleton.IsParent="True"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource BlueColor}"
-                                 extension:Skeleton.Animation="Beat">
+                                 sk:Skeleton.IsParent="True"
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource BlueColor}"
+                                 sk:Skeleton.Animation="{sk:DefaultAnimation Beat}">
                         <StackLayout Spacing="16"
                                      Orientation="Horizontal">
 
                             <ffimageloading:CachedImage WidthRequest="80"
                                                         HeightRequest="80"
                                                         Source="{Binding Item.Image}"
-                                                        extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                                        extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                                        sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                                        sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
 
                             <StackLayout Spacing="2"
                                          VerticalOptions="End"
@@ -61,41 +61,39 @@
                                 <Label Text="{Binding Item.Title}"
                                        TextColor="{StaticResource RedColor}"
                                        FontSize="Large"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                                 <Label Text="{Binding Item.Subtitle}"
                                        TextColor="{StaticResource WhiteColor}"
                                        FontSize="Medium"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                             </StackLayout>
                         </StackLayout>
                         <BoxView HeightRequest="4"
                                  BackgroundColor="{StaticResource DarkRedColor}"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                         <Label Text="{Binding Item.Description}"
                                TextColor="{StaticResource WhiteColor}"
                                FontSize="Small"
-                               extension:Skeleton.IsBusy="{Binding IsBusy}"
-                               extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                               sk:Skeleton.IsBusy="{Binding IsBusy}"
+                               sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                     </StackLayout>
 
                     <StackLayout Spacing="8"
                                  Padding="16"
-                                 extension:Skeleton.IsParent="True"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.Animation="Beat"
-                                 extension:Skeleton.AnimationInterval="200"
-                                 extension:Skeleton.AnimationParameter="1.1">
+                                 sk:Skeleton.IsParent="True"
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.Animation="{sk:DefaultAnimation Source=Beat, Interval='200', Parameter='1.1' }">
                         <StackLayout Spacing="16"
                                      Orientation="Horizontal">
 
                             <ffimageloading:CachedImage WidthRequest="80"
                                                         HeightRequest="80"
                                                         Source="{Binding Item.Image}"
-                                                        extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                                        extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                                        sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                                        sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
 
                             <StackLayout Spacing="2"
                                          VerticalOptions="End"
@@ -103,24 +101,24 @@
                                 <Label Text="{Binding Item.Title}"
                                        TextColor="{StaticResource RedColor}"
                                        FontSize="Large"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                                 <Label Text="{Binding Item.Subtitle}"
                                        TextColor="{StaticResource WhiteColor}"
                                        FontSize="Medium"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                             </StackLayout>
                         </StackLayout>
                         <BoxView HeightRequest="4"
                                  BackgroundColor="{StaticResource DarkRedColor}"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                         <Label Text="{Binding Item.Description}"
                                TextColor="{StaticResource WhiteColor}"
                                FontSize="Small"
-                               extension:Skeleton.IsBusy="{Binding IsBusy}"
-                               extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                               sk:Skeleton.IsBusy="{Binding IsBusy}"
+                               sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                     </StackLayout>
 
                 </StackLayout>

--- a/SkeletonExample/SkeletonExample/Pages/Page3.xaml
+++ b/SkeletonExample/SkeletonExample/Pages/Page3.xaml
@@ -3,7 +3,7 @@
     xmlns:pages="clr-namespace:SkeletonExample.Pages"
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:extension="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
+    xmlns:sk="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
     xmlns:ffimageloading="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms"
     x:Class="SkeletonExample.Pages.Page3"
     Title="Fade">
@@ -42,18 +42,18 @@
 
                     <StackLayout Spacing="8"
                                  Padding="16"
-                                 extension:Skeleton.IsParent="True"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource BlueColor}"
-                                 extension:Skeleton.Animation="Fade">
+                                 sk:Skeleton.IsParent="True"
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource BlueColor}"
+                                 sk:Skeleton.Animation="{sk:DefaultAnimation Fade}">
                         <StackLayout Spacing="16"
                                      Orientation="Horizontal">
 
                             <ffimageloading:CachedImage WidthRequest="80"
                                                         HeightRequest="80"
                                                         Source="{Binding Item.Image}"
-                                                        extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                                        extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                                        sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                                        sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
 
                             <StackLayout Spacing="2"
                                          VerticalOptions="End"
@@ -61,41 +61,39 @@
                                 <Label Text="{Binding Item.Title}"
                                        TextColor="{StaticResource RedColor}"
                                        FontSize="Large"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                                 <Label Text="{Binding Item.Subtitle}"
                                        TextColor="{StaticResource WhiteColor}"
                                        FontSize="Medium"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                             </StackLayout>
                         </StackLayout>
                         <BoxView HeightRequest="4"
                                  BackgroundColor="{StaticResource DarkRedColor}"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                         <Label Text="{Binding Item.Description}"
                                TextColor="{StaticResource WhiteColor}"
                                FontSize="Small"
-                               extension:Skeleton.IsBusy="{Binding IsBusy}"
-                               extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                               sk:Skeleton.IsBusy="{Binding IsBusy}"
+                               sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                     </StackLayout>
 
                     <StackLayout Spacing="8"
                                  Padding="16"
-                                 extension:Skeleton.IsParent="True"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.Animation="Fade"
-                                 extension:Skeleton.AnimationInterval="800"
-                                 extension:Skeleton.AnimationParameter="0.3">
+                                 sk:Skeleton.IsParent="True"
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.Animation="{sk:DefaultAnimation Source=Fade, Interval='800',Parameter='0.3' }">
                         <StackLayout Spacing="16"
                                      Orientation="Horizontal">
 
                             <ffimageloading:CachedImage WidthRequest="80"
                                                         HeightRequest="80"
                                                         Source="{Binding Item.Image}"
-                                                        extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                                        extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                                        sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                                        sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
 
                             <StackLayout Spacing="2"
                                          VerticalOptions="End"
@@ -103,24 +101,24 @@
                                 <Label Text="{Binding Item.Title}"
                                        TextColor="{StaticResource RedColor}"
                                        FontSize="Large"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                                 <Label Text="{Binding Item.Subtitle}"
                                        TextColor="{StaticResource WhiteColor}"
                                        FontSize="Medium"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                             </StackLayout>
                         </StackLayout>
                         <BoxView HeightRequest="4"
                                  BackgroundColor="{StaticResource DarkRedColor}"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                         <Label Text="{Binding Item.Description}"
                                TextColor="{StaticResource WhiteColor}"
                                FontSize="Small"
-                               extension:Skeleton.IsBusy="{Binding IsBusy}"
-                               extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                               sk:Skeleton.IsBusy="{Binding IsBusy}"
+                               sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                     </StackLayout>
 
                 </StackLayout>

--- a/SkeletonExample/SkeletonExample/Pages/Page4.xaml
+++ b/SkeletonExample/SkeletonExample/Pages/Page4.xaml
@@ -6,7 +6,7 @@
                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                 mc:Ignorable="d"
                 x:Class="SkeletonExample.Pages.Page4"
-                xmlns:extension="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
+                xmlns:sk="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
                 xmlns:ffimageloading="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms"
                 Title="VerticalShake">
     <ContentPage.Content>
@@ -44,18 +44,18 @@
 
                     <StackLayout Spacing="8"
                                  Padding="16"
-                                 extension:Skeleton.IsParent="True"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource BlueColor}"
-                                 extension:Skeleton.Animation="VerticalShake">
+                                 sk:Skeleton.IsParent="True"
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource BlueColor}"
+                                 sk:Skeleton.Animation="{sk:DefaultAnimation VerticalShake}">
                         <StackLayout Spacing="16"
                                      Orientation="Horizontal">
 
                             <ffimageloading:CachedImage WidthRequest="80"
                                                         HeightRequest="80"
                                                         Source="{Binding Item.Image}"
-                                                        extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                                        extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                                        sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                                        sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
 
                             <StackLayout Spacing="2"
                                          VerticalOptions="End"
@@ -63,41 +63,39 @@
                                 <Label Text="{Binding Item.Title}"
                                        TextColor="{StaticResource RedColor}"
                                        FontSize="Large"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                                 <Label Text="{Binding Item.Subtitle}"
                                        TextColor="{StaticResource WhiteColor}"
                                        FontSize="Medium"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                             </StackLayout>
                         </StackLayout>
                         <BoxView HeightRequest="4"
                                  BackgroundColor="{StaticResource DarkRedColor}"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                         <Label Text="{Binding Item.Description}"
                                TextColor="{StaticResource WhiteColor}"
                                FontSize="Small"
-                               extension:Skeleton.IsBusy="{Binding IsBusy}"
-                               extension:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
+                               sk:Skeleton.IsBusy="{Binding IsBusy}"
+                               sk:Skeleton.BackgroundColor="{StaticResource DarkBlueColor}" />
                     </StackLayout>
 
                     <StackLayout Spacing="8"
                                  Padding="16"
-                                 extension:Skeleton.IsParent="True"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.Animation="VerticalShake"
-                                 extension:Skeleton.AnimationInterval="900"
-                                 extension:Skeleton.AnimationParameter="20">
+                                 sk:Skeleton.IsParent="True"
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.Animation="{sk:DefaultAnimation Source=VerticalShake, Interval='900', Parameter='20'}">
                         <StackLayout Spacing="16"
                                      Orientation="Horizontal">
 
                             <ffimageloading:CachedImage WidthRequest="80"
                                                         HeightRequest="80"
                                                         Source="{Binding Item.Image}"
-                                                        extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                                        extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                                        sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                                        sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
 
                             <StackLayout Spacing="2"
                                          VerticalOptions="End"
@@ -105,24 +103,24 @@
                                 <Label Text="{Binding Item.Title}"
                                        TextColor="{StaticResource RedColor}"
                                        FontSize="Large"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                                 <Label Text="{Binding Item.Subtitle}"
                                        TextColor="{StaticResource WhiteColor}"
                                        FontSize="Medium"
-                                       extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                       extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                       sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                       sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                             </StackLayout>
                         </StackLayout>
                         <BoxView HeightRequest="4"
                                  BackgroundColor="{StaticResource DarkRedColor}"
-                                 extension:Skeleton.IsBusy="{Binding IsBusy}"
-                                 extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                                 sk:Skeleton.IsBusy="{Binding IsBusy}"
+                                 sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                         <Label Text="{Binding Item.Description}"
                                TextColor="{StaticResource WhiteColor}"
                                FontSize="Small"
-                               extension:Skeleton.IsBusy="{Binding IsBusy}"
-                               extension:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
+                               sk:Skeleton.IsBusy="{Binding IsBusy}"
+                               sk:Skeleton.BackgroundColor="{StaticResource BlueColor}" />
                     </StackLayout>
 
                 </StackLayout>

--- a/SkeletonExample/SkeletonExample/Pages/Page6.xaml
+++ b/SkeletonExample/SkeletonExample/Pages/Page6.xaml
@@ -6,10 +6,10 @@
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
-    x:Class="SkeletonExample.Pages.Page5"
+    x:Class="SkeletonExample.Pages.Page6"
     xmlns:sk="clr-namespace:Xamarin.Forms.Skeleton;assembly=Xamarin.Forms.Skeleton"
     xmlns:ffimageloading="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms"
-    Title="HorizontalShake">
+    Title="Custom Animation">
     <ContentPage.Content>
         <Grid ColumnSpacing="0"
               RowSpacing="8">
@@ -48,7 +48,7 @@
                                  sk:Skeleton.IsParent="True"
                                  sk:Skeleton.IsBusy="{Binding IsBusy}"
                                  sk:Skeleton.BackgroundColor="{StaticResource BlueColor}"
-                                 sk:Skeleton.Animation="{sk:DefaultAnimation HorizontalShake}">
+                                 sk:Skeleton.Animation="{Binding MyCustomAnimation}">
                         <StackLayout Spacing="16"
                                      Orientation="Horizontal">
 
@@ -88,7 +88,7 @@
                                  Padding="16"
                                  sk:Skeleton.IsParent="True"
                                  sk:Skeleton.IsBusy="{Binding IsBusy}"
-                                 sk:Skeleton.Animation="{sk:DefaultAnimation Source=HorizontalShake, Interval='900',Parameter='20'}">
+                                 sk:Skeleton.Animation="{Binding MyCustomAnimation}">
                         <StackLayout Spacing="16"
                                      Orientation="Horizontal">
 

--- a/SkeletonExample/SkeletonExample/Pages/Page6.xaml.cs
+++ b/SkeletonExample/SkeletonExample/Pages/Page6.xaml.cs
@@ -1,0 +1,13 @@
+﻿using SkeletonExample.ViewModels;
+
+namespace SkeletonExample.Pages
+{
+    public partial class Page6 : BasePage
+    {
+        public Page6()
+        {
+            InitializeComponent();
+            BindingContext = new Page6ViewModel();
+        }
+    }
+}

--- a/SkeletonExample/SkeletonExample/SkeletonExample.csproj
+++ b/SkeletonExample/SkeletonExample/SkeletonExample.csproj
@@ -22,6 +22,11 @@
     <ProjectReference Include="..\..\Xamarin.Forms.Skeleton\Xamarin.Forms.Skeleton.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="Pages\Page6.xaml.cs">
+      <DependentUpon>Page6.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Update="Pages\BasePage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/SkeletonExample/SkeletonExample/ViewModels/Page6ViewModel.cs
+++ b/SkeletonExample/SkeletonExample/ViewModels/Page6ViewModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.Skeleton.Animations;
+
+namespace SkeletonExample.ViewModels
+{
+    public class Page6ViewModel : Page5ViewModel
+    {
+        public BaseAnimation MyCustomAnimation => new MyCustomAnimation();
+    }
+}

--- a/Xamarin.Forms.Skeleton/Animations/BaseAnimation.cs
+++ b/Xamarin.Forms.Skeleton/Animations/BaseAnimation.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Forms.Skeleton.Animations
     {
         public uint Interval { get; set; }
         public double Parameter { get; set; }
-        
+
         protected abstract Task<bool> Animate(BindableObject bindable);
 
         protected abstract Task StopAnimation(BindableObject bindable);
@@ -30,6 +30,7 @@ namespace Xamarin.Forms.Skeleton.Animations
             }
             else
             {
+                Skeleton.SetAnimating(bindable, true);
                 await Animate(bindable);
                 return await Run(bindable);
             }

--- a/Xamarin.Forms.Skeleton/Animations/BeatAnimation.cs
+++ b/Xamarin.Forms.Skeleton/Animations/BeatAnimation.cs
@@ -12,7 +12,6 @@ namespace Xamarin.Forms.Skeleton.Animations
 
         protected override async Task<bool> Animate(BindableObject bindable)
         {
-            Skeleton.SetAnimating(bindable, true);
             var self = (View)bindable;
             await self.ScaleTo(this.Parameter, this.Interval);
             await self.ScaleTo(1, this.Interval);

--- a/Xamarin.Forms.Skeleton/Animations/FadeAnimation.cs
+++ b/Xamarin.Forms.Skeleton/Animations/FadeAnimation.cs
@@ -12,7 +12,6 @@ namespace Xamarin.Forms.Skeleton.Animations
 
         protected override async Task<bool> Animate(BindableObject bindable)
         {
-            Skeleton.SetAnimating(bindable, true);
             var self = (View)bindable;
             await self.FadeTo(this.Parameter, this.Interval);
             await self.FadeTo(1, this.Interval);

--- a/Xamarin.Forms.Skeleton/Animations/HorizontalShakeAnimation.cs
+++ b/Xamarin.Forms.Skeleton/Animations/HorizontalShakeAnimation.cs
@@ -12,7 +12,6 @@ namespace Xamarin.Forms.Skeleton.Animations
 
         protected override async Task<bool> Animate(BindableObject bindable)
         {
-            Skeleton.SetAnimating(bindable, true);
             var self = (View)bindable;
             await self.TranslateTo(this.Parameter, 0, this.Interval);
             await self.TranslateTo(-this.Parameter, 0, this.Interval);

--- a/Xamarin.Forms.Skeleton/Animations/VerticalShakeAnimation.cs
+++ b/Xamarin.Forms.Skeleton/Animations/VerticalShakeAnimation.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Forms.Skeleton.Animations
 
         protected override async Task<bool> Animate(BindableObject bindable)
         {
-            Skeleton.SetAnimating(bindable, true);
             var self = (View)bindable;
             await self.TranslateTo(0, this.Parameter, this.Interval);
             await self.TranslateTo(0, -this.Parameter, this.Interval);

--- a/Xamarin.Forms.Skeleton/Extensions/DefaultAnimationExtension.cs
+++ b/Xamarin.Forms.Skeleton/Extensions/DefaultAnimationExtension.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Xamarin.Forms.Skeleton.Animations;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Skeleton
+{
+    [ContentProperty(nameof(Source))]
+    public sealed class DefaultAnimationExtension : IMarkupExtension<BaseAnimation>
+    {
+        public int Interval { get; set; } = 500;
+
+        public double? Parameter { get; set; }
+
+        public AnimationTypes Source { get; set; }
+
+        public BaseAnimation ProvideValue(IServiceProvider serviceProvider)
+        {
+            switch (Source)
+            {
+                case AnimationTypes.Beat:
+                    return new BeatAnimation(Interval, Parameter);
+                case AnimationTypes.Fade:
+                    return new FadeAnimation(Interval, Parameter);
+                case AnimationTypes.VerticalShake:
+                    return new VerticalShakeAnimation(Interval, Parameter);
+                case AnimationTypes.HorizontalShake:
+                    return new HorizontalShakeAnimation(Interval, Parameter);
+                case AnimationTypes.None:
+                default:
+                    return null;
+            }
+        }
+
+        object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) =>
+            ProvideValue(serviceProvider);
+    }
+}

--- a/Xamarin.Forms.Skeleton/Skeleton.cs
+++ b/Xamarin.Forms.Skeleton/Skeleton.cs
@@ -32,23 +32,11 @@ namespace Xamarin.Forms.Skeleton
 
         public static Color GetBackgroundColor(BindableObject b) => (Color)b.GetValue(BackgroundColorProperty);
 
-        public static readonly BindableProperty AnimationProperty = BindableProperty.CreateAttached("Animation", typeof(AnimationTypes), typeof(View), AnimationTypes.None);
+        public static readonly BindableProperty AnimationProperty = BindableProperty.CreateAttached("Animation", typeof(BaseAnimation), typeof(View), null);
 
-        public static void SetAnimation(BindableObject b, AnimationTypes value) => b.SetValue(AnimationProperty, value);
+        public static void SetAnimation(BindableObject b, BaseAnimation value) => b.SetValue(AnimationProperty, value);
 
-        public static AnimationTypes GetAnimation(BindableObject b) => (AnimationTypes)b.GetValue(AnimationProperty);
-
-        public static readonly BindableProperty AnimationIntervalProperty = BindableProperty.CreateAttached("AnimationInterval", typeof(int), typeof(View), 500);
-
-        public static void SetAnimationInterval(BindableObject b, int value) => b.SetValue(AnimationIntervalProperty, value);
-
-        public static int GetAnimationInterval(BindableObject b) => (int)b.GetValue(AnimationIntervalProperty);
-
-        public static readonly BindableProperty AnimationParameterProperty = BindableProperty.CreateAttached("AnimationParameter", typeof(double?), typeof(View), null);
-
-        public static void SetAnimationParameter(BindableObject b, double? value) => b.SetValue(AnimationParameterProperty, value);
-
-        public static double? GetAnimationParameter(BindableObject b) => (double?)b.GetValue(AnimationParameterProperty);
+        public static BaseAnimation GetAnimation(BindableObject b) => (BaseAnimation)b.GetValue(AnimationProperty);
 
         #endregion Public Properties
 
@@ -77,12 +65,6 @@ namespace Xamarin.Forms.Skeleton
         internal static void SetOriginalTextColor(BindableObject b, Color value) => b.SetValue(OriginalTextColorProperty, value);
 
         internal static Color GetOriginalTextColor(BindableObject b) => (Color)b.GetValue(OriginalTextColorProperty);
-
-        internal static readonly BindableProperty BaseAnimationProperty = BindableProperty.CreateAttached("BaseAnimation", typeof(BaseAnimation), typeof(View), null);
-
-        internal static void SetBaseAnimation(BindableObject b, BaseAnimation value) => b.SetValue(BaseAnimationProperty, value);
-
-        internal static BaseAnimation GetBaseAnimation(BindableObject b) => (BaseAnimation)b.GetValue(BaseAnimationProperty);
 
         #endregion Internal Properties
 
@@ -209,48 +191,28 @@ namespace Xamarin.Forms.Skeleton
 
         private static void RunAnimation(View view)
         {
-            var animationType = GetAnimation(view);
+            var animation = GetAnimation(view);
 
-            if (animationType == AnimationTypes.None || GetAnimating(view))
+            if (animation == null || GetAnimating(view))
                 return;
 
             SetCancelAnimation(view, false);
 
-            BaseAnimation animation = null;
-
-            switch (animationType)
-            {
-                case AnimationTypes.Beat:
-                    animation = new BeatAnimation(GetAnimationInterval(view), GetAnimationParameter(view));
-                    break;
-                case AnimationTypes.Fade:
-                    animation = new FadeAnimation(GetAnimationInterval(view), GetAnimationParameter(view));
-                    break;
-                case AnimationTypes.VerticalShake:
-                    animation = new VerticalShakeAnimation(GetAnimationInterval(view), GetAnimationParameter(view));
-                    break;
-                case AnimationTypes.HorizontalShake:
-                    animation = new HorizontalShakeAnimation(GetAnimationInterval(view), GetAnimationParameter(view));
-                    break;
-                default:
-                    break;
-            }
-
             if (animation != null)
             {
-                SetBaseAnimation(view, animation);
                 animation.Start(view);
             }
         }
 
         private static void CancelAnimation(View view)
         {
-            if (GetAnimation(view) == AnimationTypes.None)
+            var animation = GetAnimation(view);
+
+            if (animation == null)
                 return;
 
             SetCancelAnimation(view, true);
 
-            var animation = GetBaseAnimation(view);
             animation.Stop(view);
         }
 


### PR DESCRIPTION
## Overview
I've created a way to use custom animations with skeleton keeping a way to use the default animations

Fixes: #9 

## Changes
- Changed `AnimationProperty` to `BaseAnimation` type
- Created an example page with custom animation
- Created a simple way to use defaults animations with markup extension

```XAML
<MyView
                      sk:Skeleton.IsBusy="{Binding IsBusy}"
                      sk:Skeleton.Animation="{sk:DefaultAnimation Fade}" />
```

## Preview

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/76272609-a8652100-625a-11ea-9152-6e588e9f9709.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>